### PR TITLE
[1.0.r1] Kbuild: Protect compilation with CONFIG_MSM_EVA

### DIFF
--- a/msm/Kbuild
+++ b/msm/Kbuild
@@ -10,13 +10,13 @@ ccflags-y += -I$(srctree)/drivers/media/platform/msm/synx/
 KBUILD_CPPFLAGS += -DCONFIG_MSM_MMRM
 
 ifeq ($(CONFIG_ARCH_WAIPIO), y)
-# include $(EVA_ROOT)/config/waipio.mk
+include $(EVA_ROOT)/config/waipioeva.conf
 KBUILD_CPPFLAGS += -DCONFIG_EVA_WAIPIO=1
 ccflags-y += -DCONFIG_EVA_WAIPIO=1
 endif
 
 ifeq ($(CONFIG_ARCH_KALAMA), y)
-# include $(EVA_ROOT)/config/waipio.mk
+include $(EVA_ROOT)/config/waipioeva.conf
 KBUILD_CPPFLAGS += -DCONFIG_EVA_KALAMA=1
 ccflags-y += -DCONFIG_EVA_KALAMA=1
 endif
@@ -40,5 +40,4 @@ msm-eva-objs := eva/cvp.o \
         eva/msm_cvp_buf.o \
         eva/msm_cvp_synx.o \
 		eva/cvp_fw_load.o
-obj-y += msm-eva.o
-
+obj-$(CONFIG_MSM_EVA) += msm-eva.o


### PR DESCRIPTION
Not all targets use this driver, hence protect it
with a flag defined in the config file.